### PR TITLE
UnityEditor.AudioUtil methods "Clip" -> "PreviewClip" name change for Unity 2020.1+

### DIFF
--- a/Assets/Plugins/Resemble/Editor/AudioPreview.cs
+++ b/Assets/Plugins/Resemble/Editor/AudioPreview.cs
@@ -55,32 +55,56 @@ namespace Resemble
 
         public static void PlayClip(AudioClip clip)
         {
+#if UNITY_2020_1_OR_NEWER
+            InvokeMethode("PlayPreviewClip", clip, 0, false);
+#else
             InvokeMethode("PlayClip", clip, 0, false);
+#endif
         }
 
         public static void PlayClip(AudioClip clip, int sample)
         {
+#if UNITY_2020_1_OR_NEWER
+            InvokeMethode("PlayPreviewClip", clip, sample, false);
+#else
             InvokeMethode("PlayClip", clip, sample, false);
+#endif
         }
 
         public static void SetClipSamplePosition(AudioClip clip, int sample)
         {
+#if UNITY_2020_1_OR_NEWER
+            InvokeMethode("SetPreviewClipSamplePosition", clip, sample);
+#else
             InvokeMethode("SetClipSamplePosition", clip, sample);
+#endif
         }
 
         public static int GetClipSamplePosition(AudioClip clip)
         {
+#if UNITY_2020_1_OR_NEWER
+            return (int) InvokeMethode("GetPreviewClipSamplePosition");
+#else
             return (int) InvokeMethode("GetClipSamplePosition", clip);
+#endif
         }
 
         public static void StopClip(AudioClip clip)
         {
+#if UNITY_2020_1_OR_NEWER
+            InvokeMethode("StopAllPreviewClips");
+#else
             InvokeMethode("StopClip", clip);
+#endif
         }
 
         public static bool IsClipPlaying(AudioClip clip)
         {
+#if UNITY_2020_1_OR_NEWER
+            return (bool) InvokeMethode("IsPreviewClipPlaying");
+#else
             return (bool) InvokeMethode("IsClipPlaying", clip);
+#endif
         }
 
         public static object InvokeMethode(string methodeName, params object[] arguments)


### PR DESCRIPTION
Clips can now be played in the inspector window in Unity 2020+ without throwing a null reference exception.